### PR TITLE
Update Codemagic configuration to prioritize AAB builds and enable Google Play publishing

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -23,8 +23,8 @@ workflows:
           cat release_notes.json
       - name: Build Android AAB
         script: |
-          # flutter build appbundle --release
-          flutter build apk --release
+          flutter build appbundle --release
+          # flutter build apk --release
     cache:
       cache_paths:
         - $HOME/.gradle/caches
@@ -32,8 +32,8 @@ workflows:
         - $CM_BUILD_DIR/platforms
         - $CM_BUILD_DIR/hooks
     artifacts:
-      # - build/app/outputs/bundle/release/*.aab
-      - build/app/outputs/flutter-apk/*.apk
+      - build/app/outputs/bundle/release/*.aab
+      # - build/app/outputs/flutter-apk/*.apk
     triggering:
       events:
         - push
@@ -43,10 +43,10 @@ workflows:
           source: true
       cancel_previous_builds: true
     publishing:
-      # google_play:
-      #   credentials: $GOOGLE_CREDENTIALS
-      #   track: internal
-      #   submit_as_draft: true
+      google_play:
+        credentials: $GOOGLE_CREDENTIALS
+        track: internal
+        submit_as_draft: true
       email:
         recipients:
           - hengsamkok76@gmail.com


### PR DESCRIPTION

- Re-enabled the AAB build command while commenting out the APK build command for clarity.
- Updated artifact output to focus on AAB format for Flutter applications.
- Configured Google Play publishing settings to be active, ensuring automatic submission of builds.

These changes refine the Codemagic workflow to support AAB outputs and streamline the publishing process.